### PR TITLE
Don't show snap /dev/loop* devices

### DIFF
--- a/udiskie-dmenu
+++ b/udiskie-dmenu
@@ -98,6 +98,11 @@ function prettyPrint(parsedUdiskieInfo) {
             devPath = stretchStr(devPath, 9);
         }
 
+        // Filter snap 
+        if (devPath.startsWith('/dev/loop')) {
+            return
+        }
+
         out += `${devPath}:  ${device.mountPath || device.label}\n`;
     });
 


### PR DESCRIPTION
Don't mess output with snap `/dev/loop` devices: 

```
$ lsblk
NAME                  MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINTS
loop0                   7:0    0  63,2M  1 loop  /snap/core20/1695
loop1                   7:1    0     4K  1 loop  /snap/bare/5
...
sda                     8:0    0 931,5G  0 disk  
└─sda1                  8:1    0 931,5G  0 part  /media/user/HDD
```